### PR TITLE
Option --log-level documentation extended

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -19,3 +19,24 @@ You can use the current build version as cli like this:
 ```
 yarn run cli -- --in=samples/simple.md --temp=tmp --out=my-document.pdf
 ```
+
+## Adjust log output
+The command `generate` has the option `--log-level`, which enables you to adjust the output log level according to your needs. The following log levels are available:
+* error
+*  warn
+*  info 
+*  verbose
+*  debug
+*  silly
+> Note: The log level of npm are used. For further information, consult [wintsonjs documentation](https://github.com/winstonjs/winston#logging-levels) (used logging framework).
+
+
+*Usage:*
+```
+yarn run markdown-document generate --log-level debug
+```
+
+*Usage during development:*
+```
+yarn run cli generate --log-level debug
+```

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -23,13 +23,12 @@ yarn run cli -- --in=samples/simple.md --temp=tmp --out=my-document.pdf
 ## Adjust log output
 The command `generate` has the option `--log-level`, which enables you to adjust the output log level according to your needs. The following log levels are available:
 * error
-*  warn
-*  info 
-*  verbose
-*  debug
-*  silly
+* warn
+* info 
+* verbose
+* debug
+* silly
 > Note: The log level of npm are used. For further information, consult [wintsonjs documentation](https://github.com/winstonjs/winston#logging-levels) (used logging framework).
-
 
 *Usage:*
 ```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,7 +20,7 @@ let argv = yargs
                 default: 'document'
             })
             .option('log-level', {
-                describe: 'Configures the log level',
+                describe: 'Configures the log level. \nUsage: --log-level [silly|debug|verbose|info|warn|error]',
                 default: 'info'
             })
             .option('temp', {


### PR DESCRIPTION
I just extended the description of the option `--log-level` in code and added a chapter into the documentation accordingly.