### PR TITLE
pdf render time set as a default property

### DIFF
--- a/src/services/options-service.ts
+++ b/src/services/options-service.ts
@@ -20,6 +20,7 @@ export interface IOptions {
 export interface IPdfOptions {
     wkhtmltopdfPath?: string;
 
+    pdfrendertimeout?: number;
     marginBottom?: number;
     marginLeft?: number;
     marginRight?: number;
@@ -119,7 +120,7 @@ export class OptionsService {
 
             pdf: {
                 wkhtmltopdfPath: require('wkhtmltopdf-installer').path,
-
+                pdfrendertimeout: 15000,
                 pageSize: 'A4',
                 orientation: 'Portrait'
             }
@@ -150,6 +151,7 @@ export class OptionsService {
 
         options.pdf.wkhtmltopdfPath = options.pdf.wkhtmltopdfPath || fallback.pdf.wkhtmltopdfPath;
         
+        options.pdf.pdfrendertimeout = options.pdf.pdfrendertimeout || fallback.pdf.pdfrendertimeout;
         options.pdf.marginBottom = options.pdf.marginBottom || fallback.pdf.marginBottom;
         options.pdf.marginLeft = options.pdf.marginLeft || fallback.pdf.marginLeft;
         options.pdf.marginRight = options.pdf.marginRight || fallback.pdf.marginRight;

--- a/src/services/pdf-service.ts
+++ b/src/services/pdf-service.ts
@@ -12,7 +12,7 @@ export class PdfService {
 
         const defer = q.defer<IRenderPdfResult>();
 
-        childProcess.execFile(options.wkhtmltopdfPath, args, { timeout: 15000 }, function(error, stdout, stderr) {
+        childProcess.execFile(options.wkhtmltopdfPath, args, { timeout: options.pdfrendertimeout }, function(error, stdout, stderr) {
             const data = {
                 error: error, 
                 stdout: stdout, 


### PR DESCRIPTION
My suggestion to solve the issue:
[renderPdfAsync hardcoded timeout fails on large documents](https://github.com/marcel-hofer/markdown-document/issues/28)

